### PR TITLE
fixing a typo in account_config.html

### DIFF
--- a/acct_mgr/templates/account_config.html
+++ b/acct_mgr/templates/account_config.html
@@ -648,7 +648,7 @@
                                      'name': 'change_uid_enabled',
                                      'checked': change_uid_enabled and 'checked' or None,
                                      'title': '[components] acct_mgr.model.*',
-                                     'value': 'true'}| >
+                                     'value': 'true'}|htmlattr} >
                             Allow administrative user ID changes.
                         </label>
                     </div>


### PR DESCRIPTION
just tried the plugin on a 1.5.4 and got a little error when loading the config page so i fixed it i guess :)